### PR TITLE
Removed html font declaration

### DIFF
--- a/templates/project/style.scss
+++ b/templates/project/style.scss
@@ -84,7 +84,6 @@
  */
 
 html{
-    font: 1em/1.5 Georgia, serif;
     background-color: #fff;
     color: #333;
 }


### PR DESCRIPTION
Setting font-size for the html element does not work well with a $base-font-size other than 16px
